### PR TITLE
Update links in Kevin Macleod library to use https

### DIFF
--- a/src/main/resources/assets/betterrecords/libraries/kevin_macleod.json
+++ b/src/main/resources/assets/betterrecords/libraries/kevin_macleod.json
@@ -4,121 +4,121 @@
     {
       "name": "Broken Reality",
       "author": "Kevin MacLeod",
-      "url": "http://incompetech.com/music/royalty-free/mp3-royaltyfree/Broken%20Reality.mp3",
+      "url": "https://incompetech.com/music/royalty-free/mp3-royaltyfree/Broken%20Reality.mp3",
       "color": "2C5E8F"
     },
     {
       "name": "Hyperfun",
       "author": "Kevin MacLeod",
-      "url": "http://incompetech.com/music/royalty-free/mp3-royaltyfree/Hyperfun.mp3",
+      "url": "https://incompetech.com/music/royalty-free/mp3-royaltyfree/Hyperfun.mp3",
       "color": "F2C983"
     },
     {
       "name": "Black Vortex",
       "author": "Kevin MacLeod",
-      "url": "http://incompetech.com/music/royalty-free/mp3-royaltyfree/Black%20Vortex.mp3",
+      "url": "https://incompetech.com/music/royalty-free/mp3-royaltyfree/Black%20Vortex.mp3",
       "color": "28284A"
     },
     {
       "name": "The Complex",
       "author": "Kevin MacLeod",
-      "url": "http://incompetech.com/music/royalty-free/mp3-royaltyfree/The%20Complex.mp3",
+      "url": "https://incompetech.com/music/royalty-free/mp3-royaltyfree/The%20Complex.mp3",
       "color": "1EE682"
     },
     {
       "name": "Oppressive Gloom",
       "author": "Kevin MacLeod",
-      "url": "http://incompetech.com/music/royalty-free/mp3-royaltyfree/Oppressive%20Gloom.mp3",
+      "url": "https://incompetech.com/music/royalty-free/mp3-royaltyfree/Oppressive%20Gloom.mp3",
       "color": "574191"
     },
     {
       "name": "Unlight",
       "author": "Kevin MacLeod",
-      "url": "http://incompetech.com/music/royalty-free/mp3-royaltyfree/Unlight.mp3",
+      "url": "https://incompetech.com/music/royalty-free/mp3-royaltyfree/Unlight.mp3",
       "color": "5E5D3B"
     },
     {
       "name": "Carefree",
       "author": "Kevin MacLeod",
-      "url": "http://incompetech.com/music/royalty-free/mp3-royaltyfree/Carefree.mp3",
+      "url": "https://incompetech.com/music/royalty-free/mp3-royaltyfree/Carefree.mp3",
       "color": "FFFF5C"
     },
     {
       "name": "Lord of the Land",
       "author": "Kevin MacLeod",
-      "url": "http://incompetech.com/music/royalty-free/mp3-royaltyfree/Lord%20of%20the%20Land.mp3",
+      "url": "https://incompetech.com/music/royalty-free/mp3-royaltyfree/Lord%20of%20the%20Land.mp3",
       "color": "618065"
     },
     {
       "name": "Moonlight Hall",
       "author": "Kevin MacLeod",
-      "url": "http://incompetech.com/music/royalty-free/mp3-royaltyfree/Moonlight%20Hall.mp3",
+      "url": "https://incompetech.com/music/royalty-free/mp3-royaltyfree/Moonlight%20Hall.mp3",
       "color": "93C2F5"
     },
     {
       "name": "The Snow Queen",
       "author": "Kevin MacLeod",
-      "url": "http://incompetech.com/music/royalty-free/mp3-royaltyfree/The%20Snow%20Queen.mp3",
+      "url": "https://incompetech.com/music/royalty-free/mp3-royaltyfree/The%20Snow%20Queen.mp3",
       "color": "FFFFFF"
     },
     {
       "name": "Jalandhar",
       "author": "Kevin MacLeod",
-      "url": "http://incompetech.com/music/royalty-free/mp3-royaltyfree/Jalandhar.mp3",
+      "url": "https://incompetech.com/music/royalty-free/mp3-royaltyfree/Jalandhar.mp3",
       "color": "E3D329"
     },
     {
       "name": "Pamgaea",
       "author": "Kevin MacLeod",
-      "url": "http://incompetech.com/music/royalty-free/mp3-royaltyfree/Pamgaea.mp3",
+      "url": "https://incompetech.com/music/royalty-free/mp3-royaltyfree/Pamgaea.mp3",
       "color": "15ED68"
     },
     {
       "name": "Local Forecast",
       "author": "Kevin MacLeod",
-      "url": "http://incompetech.com/music/royalty-free/mp3-royaltyfree/Local%20Forecast.mp3",
+      "url": "https://incompetech.com/music/royalty-free/mp3-royaltyfree/Local%20Forecast.mp3",
       "color": "8AB8E6"
     },
     {
       "name": "All This",
       "author": "Kevin MacLeod",
-      "url": "http://incompetech.com/music/royalty-free/mp3-royaltyfree/All%20This.mp3",
+      "url": "https://incompetech.com/music/royalty-free/mp3-royaltyfree/All%20This.mp3",
       "color": "8A2E2E"
     },
     {
       "name": "Junkyard Tribe",
       "author": "Kevin MacLeod",
-      "url": "http://incompetech.com/music/royalty-free/mp3-royaltyfree/Junkyard%20Tribe.mp3",
+      "url": "https://incompetech.com/music/royalty-free/mp3-royaltyfree/Junkyard%20Tribe.mp3",
       "color": "754719"
     },
     {
       "name": "Cut and Run",
       "author": "Kevin MacLeod",
-      "url": "http://incompetech.com/music/royalty-free/mp3-royaltyfree/Cut%20and%20Run.mp3",
+      "url": "https://incompetech.com/music/royalty-free/mp3-royaltyfree/Cut%20and%20Run.mp3",
       "color": "AC1919"
     },
     {
       "name": "Failing Defence",
       "author": "Kevin MacLeod",
-      "url": "http://incompetech.com/music/royalty-free/mp3-royaltyfree/Failing%20Defense.mp3",
+      "url": "https://incompetech.com/music/royalty-free/mp3-royaltyfree/Failing%20Defense.mp3",
       "color": "853333"
     },
     {
       "name": "Movement Proposition",
       "author": "Kevin MacLeod",
-      "url": "http://incompetech.com/music/royalty-free/mp3-royaltyfree/Movement%20Proposition.mp3",
+      "url": "https://incompetech.com/music/royalty-free/mp3-royaltyfree/Movement%20Proposition.mp3",
       "color": "C9C945"
     },
     {
       "name": "Hitman",
       "author": "Kevin MacLeod",
-      "url": "http://incompetech.com/music/royalty-free/mp3-royaltyfree/Hitman.mp3",
+      "url": "https://incompetech.com/music/royalty-free/mp3-royaltyfree/Hitman.mp3",
       "color": "26559A"
     },
     {
       "name": "Summon the Rawk",
       "author": "Kevin MacLeod",
-      "url": "http://incompetech.com/music/royalty-free/mp3-royaltyfree/Summon%20the%20Rawk.mp3",
+      "url": "https://incompetech.com/music/royalty-free/mp3-royaltyfree/Summon%20the%20Rawk.mp3",
       "color": "FF4800"
     }
   ]


### PR DESCRIPTION
Kevin Macleod updated his site to use HTTPS. This caused all the urls in the default library to break.