### PR TITLE
A couple fixes

### DIFF
--- a/src/main/java/tech/feldman/betterrecords/client/sound/IcyURLConnection.java
+++ b/src/main/java/tech/feldman/betterrecords/client/sound/IcyURLConnection.java
@@ -80,8 +80,8 @@ public class IcyURLConnection extends HttpURLConnection {
         socket = createSocket();
 
         socket.connect(
-                new InetSocketAddress(url.getHost(), url.getPort() != -1 ? url.getPort() : url.getDefaultPort()),
-                getConnectTimeout());
+            new InetSocketAddress(url.getHost(), url.getPort() != -1 ? url.getPort() : url.getDefaultPort()),
+            getConnectTimeout());
 
         Map<String, List<String>> requestProps = getRequestProperties();
 
@@ -92,7 +92,19 @@ public class IcyURLConnection extends HttpURLConnection {
         outputStream = socket.getOutputStream();
         inputStream = socket.getInputStream();
 
-        writeLine("GET " + ("".equals(url.getPath()) ? "/" : url.getPath()) + " HTTP/1.1");
+
+        String requestPath = url.getPath();
+        // We need to set the slash if no path was given
+        if ("".equals(requestPath)) requestPath = "/";
+
+        // Append the query string, if any
+        String query = url.getQuery();
+        if ("".equals(query)) {
+            requestPath += "?" + query;
+        }
+
+        // Use HTTP 1.0 because of no Transfer-Encoding: chunked
+        writeLine("GET " + requestPath + " HTTP/1.0");
         writeLine("Host: " + url.getHost());
 
         if (requestProps != null) {
@@ -226,17 +238,12 @@ public class IcyURLConnection extends HttpURLConnection {
      * Reads one response header line and adds it to the headers map.
      */
     protected void parseHeaderLine(String line) {
-        int len = 2;
-        int n = line.indexOf(": ");
+        int n = line.indexOf(":");
+        if (n == -1) return;
 
-        if (n == -1) {
-            len = 1;
-            n = line.indexOf(':');
-            if (n == -1) return;
-        }
-
-        String key = line.substring(0, n).toLowerCase();
-        String val = line.substring(n + len);
+        // Make the header key lowercase, so we can find it easier afterwards
+        String key = line.substring(0, n).toLowerCase().trim();
+        String val = line.substring(n + 1).trim();
 
         List<String> list = headers.get(key);
 
@@ -271,7 +278,7 @@ public class IcyURLConnection extends HttpURLConnection {
     /**
      * Reads one response line.
      *
-     * @return the line without any new-line character.
+     * @return the line without any newline character.
      */
     protected String readLine() throws IOException {
         StringBuilder sb = new StringBuilder();

--- a/src/main/java/tech/feldman/betterrecords/client/sound/IcyURLConnection.java
+++ b/src/main/java/tech/feldman/betterrecords/client/sound/IcyURLConnection.java
@@ -99,7 +99,7 @@ public class IcyURLConnection extends HttpURLConnection {
 
         // Append the query string, if any
         String query = url.getQuery();
-        if ("".equals(query)) {
+        if (!"".equals(query)) {
             requestPath += "?" + query;
         }
 


### PR DESCRIPTION
Use HTTP/1.0 so that we can process data without transfer encoding (would cause audio skips)
Make Frequency Tuner UI easier to work with (use tab to switch input fields, esc to exit ui)
Support GET querystring in ICY URLs, fixes #90