### PR TITLE
configurable speaker wire distance

### DIFF
--- a/src/main/kotlin/tech/feldman/betterrecords/ModConfig.kt
+++ b/src/main/kotlin/tech/feldman/betterrecords/ModConfig.kt
@@ -81,6 +81,11 @@ object ModConfig {
         var flashMode = -1
 
         @JvmField
+        @Config.Comment("Max speaker wire length")
+        @Config.RangeInt(min = 5, max = 80)
+        var wireLength = 7
+
+        @JvmField
         @Config.Comment("Should the mod's built in libraries be loaded")
         var loadDefaultLibraries = true
     }

--- a/src/main/kotlin/tech/feldman/betterrecords/item/ItemWire.kt
+++ b/src/main/kotlin/tech/feldman/betterrecords/item/ItemWire.kt
@@ -24,6 +24,7 @@
 package tech.feldman.betterrecords.item
 
 import tech.feldman.betterrecords.api.connection.RecordConnection
+import tech.feldman.betterrecords.ModConfig
 import tech.feldman.betterrecords.api.wire.IRecordWire
 import tech.feldman.betterrecords.api.wire.IRecordWireHome
 import tech.feldman.betterrecords.api.wire.IRecordWireManipulator
@@ -56,7 +57,7 @@ class ItemWire(name: String) : ModItem(name), IRecordWireManipulator {
                 val y1 = -(pos.y - if (it.fromHome) it.y1 else it.y2).toFloat()
                 val z1 = -(pos.z - if (it.fromHome) it.z1 else it.z2).toFloat()
 
-                if (Math.sqrt(Math.pow(x1.toDouble(), 2.toDouble()) + Math.pow(y1.toDouble(), 2.toDouble()) + Math.pow(z1.toDouble(), 2.toDouble())) > 7 || it.sameInitial(pos.x, pos.y, pos.z)) {
+                if (Math.sqrt(Math.pow(x1.toDouble(), 2.toDouble()) + Math.pow(y1.toDouble(), 2.toDouble()) + Math.pow(z1.toDouble(), 2.toDouble())) > ModConfig.client.wireLength || it.sameInitial(pos.x, pos.y, pos.z)) {
                     connection = null
                     return EnumActionResult.PASS
                 }


### PR DESCRIPTION
adds a new `wireLength` client config option to speaker wire length. valid values are
between 7 (the default and original value) and 70 blocks.